### PR TITLE
Set LANG=C when executing rpmbuild

### DIFF
--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -101,7 +101,7 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         os.system('ls -lR')
         command = [find_executable('rpmbuild'), '-ba', 'package.spec']
         logger.debug('Running command %r', ' '.join(command))
-        output = subprocess.check_output(command)
+        output = subprocess.check_output(command, env={'LANG': 'C'})
         output = output.decode(errors='ignore')
         packages = []
         for line in output.split('\n'):


### PR DESCRIPTION
The rpm plugin expects `rpmbuild` to output a line starting with `Wrote: `, but the output might be localized when custom locale is set.

This change forces `rpmbuild` to output non-localized lines by passing `LANG=C`.