### PR TITLE
Allow overriding pip executable path

### DIFF
--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -70,6 +70,10 @@ class InvirtualenvPlugin(object):
         python_executable = find_executable(basepython)
         if not python_executable:
             python_executable = sys.executable
+
+        # Check to see if deploy.conf has basepip
+        if self.config['global'].get('basepip', None):
+            return [python_executable, self.config['global'].get('basepip')]
         bin_dir = os.path.dirname(python_executable)
         pip_command = os.path.join(bin_dir, 'pip')
         return [python_executable, pip_command]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist = pycodestyle, pylint, py27, py35, py36, py37
 deps = 
 	pytest
 	pytest-cov
+	mock
 commands = 
 	pytest --cov=invirtualenv --cov-report=xml:cobertura.xml --cov-report term-missing tests/
 


### PR DESCRIPTION
invirtualenv always tries to fuzzy detect pip executable's
path and name from python executable's base dir. This causes
problems with python2.7 because python27 install pip as
BASE_DIR/pip2.7 instead of BASE_DIR/pip. So let the users override
pip executable path via deploy.conf