### PR TITLE
Update setup.cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - pip install tox
 
 script:
-  - tox -r
+  - tox
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ script:
 matrix:
   fast_finish: true
 
+after_success:
+  codecov
+  
 notifications:
   irc:
     channels: "irc.freenode.org#invirtualenv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 install:
   - pip install --upgrade setuptools
-  - pip install tox
+  - pip install tox codecov
 
 script:
   - tox

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/yahoo/invirtualenv.svg?branch=master
     :target: https://travis-ci.org/yahoo/invirtualenv
 
+.. image:: https://codecov.io/gh/yahoo/invirtualenv/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/yahoo/invirtualenv
+
 .. image:: https://readthedocs.org/projects/invirtualenv/badge/?version=latest
     :target: https://invirtualenv.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,6 @@ invirtualenv.plugin =
     docker        = invirtualenv_plugins.docker:InvirtualenvDocker
     parsedconfig  = invirtualenv_plugins.parsedconfig:InvirtualenvParsedConfig
     rpm           = invirtualenv_plugins.rpm:InvirtualenvRPM
+
+[bdist_wheel]
+universal=1

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps =
 	coveralls
 commands = 
 	pytest --cov=invirtualenv --cov-report=xml:cobertura.xml --cov-report term-missing tests/
-	coveralls
-passenv = COVERALLS_REPO_TOKEN
+	# coveralls
+passenv = CI COVERALLS_REPO_TOKEN
 
 [testenv:pycodestyle]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 	pytest-cov
 	coveralls
 commands = 
-	pytest --cov=invirtualenv --cov-report=xml:cobertura.xml --cov-report term-missing tests/
+	pytest --cov=invirtualenv --cov-report term-missing tests/
 	# coveralls
 passenv = CI COVERALLS_REPO_TOKEN
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = pycodestyle, pylint, py27, py35, py36, py37
 deps = 
 	pytest
 	pytest-cov
-	coveralls
+	# coveralls
 commands = 
 	pytest --cov=invirtualenv --cov-report term-missing tests/
 	# coveralls


### PR DESCRIPTION
Make sure the wheel packages are universal since invirtualenv can run on 2.x and 3.x currently and the packaging is breaking rpm packages that list a python 2.x interpreter.