### PR TITLE
Make use of virtualenv if it exists in the system

### DIFF
--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -22,8 +22,9 @@ AutoReqProv: no
 BuildArch: noarch
 # If basepython is specified/set. Make it as RPM requirement.
 %if {{global['basepython']}}
-Requires: {{global['basepython']}}
+Requires(post): {{global['basepython']}}
 %fi
+Requires(post): /usr/bin/which
 
 %description
 {{rpm_package['description']|default('No description')}}

--- a/invirtualenv_plugins/rpm_scripts/post_install.py
+++ b/invirtualenv_plugins/rpm_scripts/post_install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import logging
 import os
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     try:
         venv_directory = build_deploy_virtualenv(update_existing=True)
         update_config(venv_directory)
-    except:
+    except Exception:
         print('Unable to create the python virtualenv', file=sys.stderr)
         logger.exception('The virtualenv create failed, removing venv_directory')
         if venv_directory and os.path.exists(venv_directory):
@@ -62,7 +62,7 @@ if __name__ == "__main__":
                 link_deployed_bin_files(venv_directory, '/usr/bin')
             except ImportError:
                 print('WARNING: The installed version of invirtualenv does not support linking bin files')
-    except:
+    except Exception:
         logger.exception('An error occurred linking bin files into %r', os.path.dirname(sys.executable))
 
     print('Created virtualenv %r' % venv_directory)

--- a/invirtualenv_plugins/rpm_scripts/pre_uninstall.py
+++ b/invirtualenv_plugins/rpm_scripts/pre_uninstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import logging
 import os


### PR DESCRIPTION
Using python3's venv module has a downside. It doesn't allow us
to specify other python versions to be used in the virtualenv.

If basepython is specified always make it as a RPM requirement for
the RPM package.

Use explicit python versions in the shebang