### PR TITLE
Add python-virtualenv rpm as a dependency

### DIFF
--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -21,7 +21,6 @@ URL: {{global['url']|default('https://github.com/yahoo/invirtualenv')}}
 AutoReqProv: no
 BuildArch: noarch
 Requires(post): {{global['basepython']}}
-Requires(post): /usr/bin/which
 Requires(post): python-virtualenv
 
 %description

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -22,6 +22,7 @@ AutoReqProv: no
 BuildArch: noarch
 Requires(post): {{global['basepython']}}
 Requires(post): /usr/bin/which
+Requires(post): python-virtualenv
 
 %description
 {{rpm_package['description']|default('No description')}}
@@ -38,18 +39,9 @@ chmod 755 %{buildroot}/usr/share/%{name}-%{version}/package_scripts/pre_uninstal
 
 %post
 export PATH=$PATH:/opt/python/bin:/usr/local/bin
-virtualenv_path=`which virtualenv ||:`
-if [ -z $virtualenv_path ]
-then
-    # NOTE(saga): Virtualenv binary not found. Try and use python3's virtualenv
-    # module. However it doesn't support specifying custom python_exe path (-p)
-    python3 -m venv /usr/share/%{name}-%{version}/invirtualenv_deployer
-else
-    $virtualenv_path -p {{global['basepython']}} /usr/share/%{name}-%{version}/invirtualenv_deployer
-fi
+virtualenv -p {{global['basepython']}} /usr/share/%{name}-%{version}/invirtualenv_deployer
 /usr/share/%{name}-%{version}/invirtualenv_deployer/bin/pip install -q --no-index --find-links=/usr/share/%{name}-%{version}/wheels invirtualenv configparser
 cd /usr/share/%{name}-%{version}
-#/usr/share/%{name}-%{version}/invirtualenv_deployer/bin/deploy_virtualenv
 /usr/share/%{name}-%{version}/invirtualenv_deployer/bin/python /usr/share/%{name}-%{version}/package_scripts/post_install.py
 
 %preun


### PR DESCRIPTION
Remove all the complicated logic about finding virtualenv
and python3 virtualenv module and just make python-virtualenv
RPM as a dependency to all the RPMs built using invirtualenv