### PR TITLE
Fix pre_uninstall.py doesn't find deploy.conf

### DIFF
--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -39,7 +39,7 @@ chmod 755 %{buildroot}/usr/share/%{name}-%{version}/package_scripts/pre_uninstal
 %post
 export PATH=$PATH:/opt/python/bin:/usr/local/bin
 virtualenv -p {{global['basepython']}} /usr/share/%{name}-%{version}/invirtualenv_deployer
-/usr/share/%{name}-%{version}/invirtualenv_deployer/bin/pip install -q --no-index --find-links=/usr/share/%{name}-%{version}/wheels invirtualenv configparser
+/usr/share/%{name}-%{version}/invirtualenv_deployer/bin/pip install -q --find-links=/usr/share/%{name}-%{version}/wheels invirtualenv configparser
 cd /usr/share/%{name}-%{version}
 /usr/share/%{name}-%{version}/invirtualenv_deployer/bin/python /usr/share/%{name}-%{version}/package_scripts/post_install.py
 

--- a/invirtualenv_plugins/rpm_scripts/pre_uninstall.py
+++ b/invirtualenv_plugins/rpm_scripts/pre_uninstall.py
@@ -9,11 +9,19 @@ from invirtualenv.config import get_configuration_dict
 
 
 if __name__ == "__main__":
-    if not os.path.exists('deploy.conf'):
+    # /usr/share/<packagename-version>/package_scripts
+    this_script_dir = os.path.dirname(os.path.realpath(__file__))
+    path_bits = this_script_dir.split(os.path.sep)
+    # Remove leading package_scripts from the path
+    path_bits.remove('package_scripts')
+    # /usr/share/<packagename-version>/
+    data_dir = os.path.sep.join(path_bits)
+    deploy_conf = os.path.join(data_dir, 'deploy.conf')
+    if not os.path.exists(deploy_conf):
         print("No 'deploy.conf' found.  Doing nothing", file=sys.stderr)
         sys.exit(0)
 
-    config = get_configuration_dict()
+    config = get_configuration_dict(deploy_conf)
     venv_dir = config['global'].get('virtualenv_deploy_dir', None)
 
     if venv_dir and os.path.exists(venv_dir):


### PR DESCRIPTION
pre_uninstall.py is called by RPM uninstall (preun section).
It can't really find the deploy.conf. Lets teach pre_uninstall.py
where to find deploy.conf so that it can uninstall the RPM and
remove the generated virtualenv right.

Also remove --no-index from %post section of the RPM and let it
fetch from pypi to increase the probability of the RPM install
to be successful.