### PR TITLE
Update screwdriver.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -36,7 +36,7 @@ jobs:
 
     -   install_tox: |
             $BASE_PYTHON -m venv /tmp/functional_test
-            /tmp/functional_test/bin/pip install pytest
+            /tmp/functional_test/bin/pip install pytest wheel jinja2 requests six>=1.5 virtualenv
             /tmp/functional_test/bin/pip install --index-url=https://test.pypi.org/simple $PACKAGE_NAME==$PACKAGE_VERSION
     -   validate_code: |
             cd /tmp


### PR DESCRIPTION
The testing of the test.pypi.org package does not work because all the dependencies for the package aren't on test.pypi.org and if we allow use of both test and prod indexes it's possible we'll get an invirtualenv package from the prod repo not the test repo.

This fix pre-installs the dependencies from the prod pypi endpoint and then installs the package from test.pypi.org.