### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,8 @@ long_description = file:README.md
 long_description_content_type = text/markdown
 name = invirtualenv
 project_urls =
-    Source = https://github.com/yahoo/invirtualenv
+    Source Code = https://github.com/yahoo/invirtualenv
+    Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
 version = 19.5.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages =
     invirtualenv_plugins
     invirtualenv_plugins.rpm_scripts
 
-python_requires = >=2.7.6
+python_requires = >=2.7.5
 zip_safe = True
 
 [options.entry_points]


### PR DESCRIPTION
Downgrade the python_requires to allow the invirtualenv docker plugin to bootstrap on operating systems with really old python interpreters (RHEL/CentOS)