### PR TITLE
Update docker_build.sh

### DIFF
--- a/invirtualenv_plugins/docker_scripts/docker_build.sh
+++ b/invirtualenv_plugins/docker_scripts/docker_build.sh
@@ -87,7 +87,7 @@ function install_invirtualenv {
 
     ${venv_pip} install -U setuptools
     ${venv_pip} install -U wheel virtualenv
-    ${venv_pip} install "pip<19.0"
+    ${venv_pip} install -U "pip<19.0"
     ${venv_pip} install -U invirtualenv
     deactivate || true
 }


### PR DESCRIPTION
On systems with older python 2.x interpreters they may not have a pip command that can handle python version specific dependencies which causes the configparser package to not get installed.

## Description
Forces pip to upgrade when installing pip in the boostrap

## Motivation and Context
Docker container build is broken on some versions of RHEL

