### PR TITLE
Copy the file instead of moving it since it can generate an OSError i…

### DIFF
--- a/invirtualenv/cli.py
+++ b/invirtualenv/cli.py
@@ -4,6 +4,7 @@ Command line interface to invirtualenv v2
 import argparse
 import logging
 import os
+import shutil
 import sys
 from .config import get_configuration_dict
 from .contextmanager import InTemporaryDirectory
@@ -106,7 +107,7 @@ def create_package_command(args):
         package_file = create_package(args.package_type)
         dest_package_file = os.path.join(orig_directory, os.path.basename(package_file))
         if os.path.exists(package_file):
-            os.rename(package_file, dest_package_file)
+            shutil.copy(package_file, dest_package_file)
 
     if package_file:
         logging.debug('Generated package file: %s' % dest_package_file)


### PR DESCRIPTION
## Description

Copy the generated package archive instead of moving.  Moving can cause an OSError exception when the source and dest are on different filesystems.

## Motivation and Context

RPM generate generates an OSError exception without this change

## How Has This Been Tested?

This was tested on a Fedora container and verified to generate an rpm package.


## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

