### PR TITLE
Docker build fix

### DIFF
--- a/invirtualenv/cli.py
+++ b/invirtualenv/cli.py
@@ -4,6 +4,7 @@ Command line interface to invirtualenv v2
 import argparse
 import logging
 import os
+import shutil
 import sys
 from .config import get_configuration_dict
 from .contextmanager import InTemporaryDirectory
@@ -106,7 +107,7 @@ def create_package_command(args):
         package_file = create_package(args.package_type)
         dest_package_file = os.path.join(orig_directory, os.path.basename(package_file))
         if os.path.exists(package_file):
-            os.rename(package_file, dest_package_file)
+            shutil.copy(package_file, dest_package_file)
 
     if package_file:
         logging.debug('Generated package file: %s' % dest_package_file)

--- a/invirtualenv/cli.py
+++ b/invirtualenv/cli.py
@@ -105,9 +105,10 @@ def create_package_command(args):
         with open(args.deploy_conf, 'w') as deploy_conf_handle:
             deploy_conf_handle.write(deploy_config_contents)
         package_file = create_package(args.package_type)
-        dest_package_file = os.path.join(orig_directory, os.path.basename(package_file))
-        if os.path.exists(package_file):
-            shutil.copy(package_file, dest_package_file)
+        if package_file:
+            dest_package_file = os.path.join(orig_directory, os.path.basename(package_file))
+            if os.path.exists(package_file):
+                shutil.copy(package_file, dest_package_file)
 
     if package_file:
         logging.debug('Generated package file: %s' % dest_package_file)

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -115,11 +115,12 @@ class InvirtualenvPlugin(object):
                 self.loaded_configuration.write(deploy_conf_handle)
             generate_parsed_config_file('deploy.conf.unparsed', 'deploy.conf')
             package = self.run_package_command(hashes, wheel_dir=wheel_dir)  # pylint: disable=E1128,E1111
-            if package:
+            if package and os.path.exists(package):
                 source = package
                 dest = os.path.join(original_directory, os.path.basename(package))
                 shutil.copyfile(source, dest)
                 return dest
+            return package
 
     def generate_wheel_archive(self, filename=None):
         if not filename:

--- a/invirtualenv_plugins/docker.py
+++ b/invirtualenv_plugins/docker.py
@@ -56,10 +56,8 @@ DOCKERFILE_TEMPLATE = """FROM {{docker_container['base_image']|default('ubuntu:1
 # Set up invirtualenv in the container
 ENV PATH="/var/lib/invirtualenv/installvenv/bin:${PATH}"
 COPY docker_build.sh /tmp/docker_build.sh
-COPY deploy.conf /var/lib/invirtualenv/deploy.conf
-RUN chmod 755 /tmp/docker_build.sh
-RUN /tmp/docker_build.sh
-RUN rm /tmp/docker_build.sh
+# COPY deploy.conf /var/lib/invirtualenv/deploy.conf
+RUN chmod 755 /tmp/docker_build.sh && /tmp/docker_build.sh && rm /tmp/docker_build.sh
 
 {% if docker_container['run_after'] %}# Post Invirtualenv Commands
 {% for runline in docker_container['run_after'] %}RUN {{runline}}
@@ -171,4 +169,5 @@ class InvirtualenvDocker(InvirtualenvPlugin):
         command = [find_executable('docker'), 'build', '-t', container_tag, '.']
         logger.debug('Running command %r', ' '.join(command))
         subprocess.check_call(command)
+        logger.debug('Created container %r', container_tag)
         return container_tag


### PR DESCRIPTION
## Description

Fixes docker builds on some containers that have python 2.6 interpreters or have working interpreters already installed.

This change adds a new function to search for existing python interpreters already installed in the container.  It specifically looks for the python interpreters installed in the manylinux containers.

If a python3 interpreter is found, it verifies it has a working venv module and if so uses it instead of installing a bootstrap python interpreter.

## Motivation and Context

Docker container builds fail with some containers because python 2.6 interpreters are to old to bootstrap invirtualenv into the container.

## How Has This Been Tested?

This was tested by generating docker containers using the new version of invirtualenv.

This has been tested building containers on RHEL6 based manylinux2010 container, fedora:latest container and ubuntu latest container.
## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
