### PR TITLE
Fix to ensure RPM bin links survive updates

### DIFF
--- a/changelog.d/65.bugfix.md
+++ b/changelog.d/65.bugfix.md
@@ -1,0 +1,1 @@
+Update the rpm scriptlets to ensure linked bin files are not deleted when upgrading the package.

--- a/invirtualenv/config.py
+++ b/invirtualenv/config.py
@@ -60,11 +60,11 @@ def cast_types(configuration, types_dict=None):
                 elif setting_type is list:
                     setting_type = str_to_list
                 configuration[section][key] = setting_type(value)
-                logger.debug(
-                    'Forced value %r of type %r to type %r, result is %r',
-                    value, type(value), setting_type,
-                    configuration[section][key]
-                )
+                # logger.debug(
+                #     'Forced value %r of type %r to type %r, result is %r',
+                #     value, type(value), setting_type,
+                #     configuration[section][key]
+                # )
             except (KeyError, TypeError):
                 pass
 
@@ -101,7 +101,7 @@ def get_configuration(configuration=None):
     except AttributeError:
         config.readfp(io.BytesIO(config_defaults()))
 
-    logger.debug('Working with default dict: %r', config_defaults())
+    # logger.debug('Working with default dict: %r', config_defaults())
     config.read(configuration)
     return config
 

--- a/invirtualenv/deploy.py
+++ b/invirtualenv/deploy.py
@@ -200,10 +200,9 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
     # display_header('Parsing the configuration')
     config = get_configuration_dict(configuration=configuration)
     if not arguments:
-        logger.debug(
-            'No arguments dictionary passed, parsing command line arguments')
+        logger.debug('No arguments dictionary passed, parsing command line arguments')
         arguments = parse_arguments(configuration=configuration)
-        logger.debug('Arguments are: %s', arguments)
+        # logger.debug('Arguments are: %s', arguments)
 
     if verbose is None:
         verbose = arguments.verbose
@@ -397,14 +396,14 @@ def link_deployed_bin_files(venv, destbin):  # pragma: no cover
     for filename in deployed_bin_files(venv):
         source_filename = os.path.expanduser(os.path.join(venv_bin, filename))
         dest_filename = os.path.expanduser(os.path.join(destbin, filename))
-        if os.path.exists(dest_filename):
+        if os.path.exists(dest_filename) and not os.path.islink(dest_filename):
             logger.debug('Not overwriting existing file %r', dest_filename)
             continue
 
         # os.path.exists() returns False for broken symlinks so we need to check
         # to see if the dest_filename is a symlink.
         if os.path.islink(dest_filename):
-            logger.warning('Removing broken symlink %r', dest_filename)
+            logger.debug('Removing broken symlink %r', dest_filename)
             os.unlink(dest_filename)
         os.symlink(source_filename, dest_filename)
         linked_files.append(dest_filename)

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -266,7 +266,7 @@ def install_requirements(
         Install wheels from local directory
         Default=False
     """
-    logger.info(
+    logger.debug(
         'Installing requirements from requirements file: %r '
         'into virtualenv %r as user %r',
         requirements, virtualenv, user
@@ -307,7 +307,7 @@ def install_requirements(
         chown_recursive('pip_cache_dir', user_uid, user_gid)
 
     for requirement in requirements:
-        logger.info('Installing python requirements from file %r', requirement)
+        logger.debug('Installing python requirements from file %r', requirement)
         command = [
             os.path.join(virtualenv_bin, 'pip'),
             'install',
@@ -323,8 +323,8 @@ def install_requirements(
             if verbose:
                 print(output.decode())
         except subprocess.CalledProcessError as error:
-            print(error.output.decode())
             logger.exception('PIP install operation failed')
+            print(error.output.decode())
             raise BuildException('PIP install operation failed')
 
     after_binfiles_filename = os.path.join(virtualenv, 'conf/binfiles_postdeploy.json')

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -37,6 +37,7 @@ chmod 755 %{buildroot}/usr/share/%{name}_%{version}/package_scripts/post_install
 chmod 755 %{buildroot}/usr/share/%{name}_%{version}/package_scripts/pre_uninstall.py
 
 %post
+export RPM_ARG="$1"
 export PATH=$PATH:/opt/python/bin:/usr/local/bin
 virtualenv -p {{global['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip install -q --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
@@ -44,13 +45,14 @@ cd /usr/share/%{name}_%{version}
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python /usr/share/%{name}_%{version}/package_scripts/post_install.py
 
 %preun
+export RPM_ARG="$1"
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python /usr/share/%{name}_%{version}/package_scripts/pre_uninstall.py
 
 %postun
 rm -rf /usr/share/%{name}_%{version}
 
 %files
-%defattr(0755, root, root)
+%defattr(0755, root, root, 0755)
 /usr/share/%{name}_%{version}/*
 {% if rpm_package['files'] %}
 {% endif %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 description = Tool to abstract host deployment of Python packages
 description_content_type = text/markdown
 description-file = README.rst
@@ -19,7 +20,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 19.5.0
+version = 20.2.34
 
 [options]
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ package_name = invirtualenv
 
 [tox]
 skip_missing_interpreters = True
-envlist = py27, py35, py36, py37, py38
+envlist = py35, py36, py37, py38
 
 [testenv]
 deps = 


### PR DESCRIPTION
When  an rpm package is upgraded that has the link_bin_files flag set in the configuration, the symlinks get deleted.

## Description

During upgrade the post_uninstall script for the old package is run after the post_install script of the new package.

Since the post_install script creates the symlinks and the post_uninstall removes the symlinks after installing this results in the symlinks being removed.

This change makes the post_uninstall script only remove the symlinks if it is not performing an upgrade.

## Related Issue

This is to fix issue #65 

## Motivation and Context

This keeps the symlinks in the bin directory from disappearing on upgrade.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project `tox -e pycodestyle` returns no errors.
- [X] My code has no unaddressed Liniting issues and the `tox -e pylint` command returns no errors.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTING](./Contributing.md)** document.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
