### PR TITLE
Fix rpm generation for rhel8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+/*.rpm
 
 # Installer logs
 pip-log.txt
@@ -94,9 +95,14 @@ package_metadata.json
 /deploy.conf
 /.cache
 /.pytest_cache
-/venv
-.coveragerc
+/venv*
+.coverage*
 .idea/
 .python_screwdriver_local.json
 cobertura.xml
 test.dockerfile
+
+# Reports
+/coverage.xml
+/invirtualenv.spec
+/pytest_py*.xml

--- a/changelog.d/68.bugfix.md
+++ b/changelog.d/68.bugfix.md
@@ -1,0 +1,1 @@
+Generates rpm packages that have the proper dependencies to bootstrap the python virtualenv on all currently supported versions of CentOS/RHEL

--- a/invirtualenv/__init__.py
+++ b/invirtualenv/__init__.py
@@ -5,32 +5,21 @@
 """
 InVirtualEnv Python Virtualenv Installer Module
 """
-import json
-import os
-import sys
-
+try:
+    import pkg_resources
+    __version__: str = pkg_resources.get_distribution("invirtualenv").version
+except ImportError:
+    ___version__ = '0.0.0'
 
 __copyright__ = "Copyright 2016, Yahoo Inc."
-__directory__ = os.path.dirname(__file__)
-__version__ = '0.0.0'
-
-if hasattr(sys, "_MEIPASS"):
-    __directory__ = sys._MEIPASS  # pragma: no cover
-
-__metadata_filename__ = os.path.join(__directory__, 'package_metadata.json')
-if os.path.exists(__metadata_filename__):  # pragma: no cover
-    with open(__metadata_filename__) as __metadata_handle:
-        __metadata__ = json.load(__metadata_handle)
-        __version__ = __metadata__['version']
-
-del __metadata_filename__
-
 __all__ = [
     'config',
+    'contextmanager',
     'deploy',
     'exceptions',
     'package',
     'plugin',
+    'plugin_base',
     'utility',
     'virtualenv'
 ]

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -32,6 +32,7 @@ class InvirtualenvPlugin(object):
         self.config_file = config_file
         self.config = get_configuration_dict(configuration=config_file)
         self.loaded_configuration = get_configuration(configuration=config_file)
+        self.add_plugin_configuration()
 
     # Methods that need to be written for each plugin type
     def run_package_command(self, package_hashes, wheel_dir='wheels'):
@@ -161,6 +162,13 @@ class InvirtualenvPlugin(object):
                     hashes[filename] = '='.join(subprocess.check_output(cmd).decode().split(os.linesep)[1].split('=')[1:])  # nosec
                     logger.debug('Got requirements line %r', hashes[filename])
         return hashes
+
+    def add_plugin_configuration(self):
+        """
+        Add any specific plugin configuration values to the configuration
+        :return:
+        """
+        pass
 
     def render_template_with_config(self, template_str=None):
         if not template_str:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -63,7 +63,7 @@ jobs:
             -   postinstall_utility: |
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
-        requires: [verify_test_package]
+        requires: [~commit, ~pr]
 
     verify_rpm_centos8:
         template: python/package_rpm
@@ -97,7 +97,7 @@ jobs:
             -   postinstall_utility: |
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
-        requires: [verify_test_package]
+        requires: [~commit, ~pr]
 
     verify_rpm_fedora:
         template: python/package_rpm
@@ -131,7 +131,7 @@ jobs:
             - postinstall_utility: |
                 # Install the version from this repo instead of the invirtualenv from pypi
                 $BASE_PYTHON -m pip install .
-        requires: [verify_test_package]
+        requires: [~commit, ~pr]
 
     # Generate a package version to publish
     generate_version:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,76 +1,158 @@
 version: 4
 shared:
-  environment:
-    CHANGELOG_FILENAME: docs/changelog.md
-    PACKAGE_DIRECTORY: invirtualenv
+    environment:
+        CHANGELOG_FILENAME: docs/changelog.md
+        PACKAGE_DIRECTORY: invirtualenv
 
 jobs:
-  validate_test:
-    template: python/validate_unittest
-    requires: [~commit, ~pr]
+    # Run the unittests
+    validate_test:
+        template: python/validate_unittest
+        requires: [~commit, ~pr]
 
-  validate_lint:
-    template: python/validate_lint
-    requires: [~commit, ~pr]
+    # Run the code linter
+    validate_lint:
+        template: python/validate_lint
+        requires: [~commit, ~pr]
 
-  validate_codestyle:
-    template: python/validate_codestyle
-    requires: [~commit, ~pr]
+    # Validate code follows the style guide
+    validate_codestyle:
+        template: python/validate_codestyle
+        requires: [~commit, ~pr]
 
-  validate_safetydb:
-    template: python/validate_safety
-    requires: [~commit, ~pr]
-    
-  validate_security:
-    template: python/validate_security
-    requires: [~commit, ~pr]
-    
-  generate_version:
-    template: python/generate_version
-    requires: [~commit]
+    # Check for use of package dependencies that have security issues
+    validate_dep:
+        template: python/validate_safety
+        requires: [~commit, ~pr]
 
-  publish_test_pypi:
-    template: python/package_python
-    environment:
-      PUBLISH: True
-      TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-    requires: [validate_test, validate_lint, validate_codestyle, validate_safetydb, validate_security, generate_version]
+    # Check code for common security issues
+    validate_security:
+        template: python/validate_security
+        requires: [~commit, ~pr]
 
-  verify_test_package:
-    template: python/validate_pypi_package
-    environment:
-        PYPI_INDEX_URL: https://test.pypi.org/simple
-    requires: [publish_test_pypi]
+    # Check that the code can generate a valid rpm packages
+    verify_rpm_centos7:
+        template: python/package_rpm
+        environment:
+            PUBLISH: False
+        image: centos:7
+        steps:
+            -   postmotd: |
+                    cat > deploy.conf <<EOF
+                    [global]
+                    name = serviceping
+                    description = invirtualenv utility for deploying python applicatons
+                    version = 18.8.1
+                    link_bin_files = True
+                    virtualenv_dir = /var/lib/virtualenvs
+                    basepython=/usr/bin/python3
+
+                    [pip]
+                    deps:
+                        serviceping==18.8.1
+
+                    [rpm_package]
+                    basepython=/usr/bin/python3
+                    deps:
+                        python3
+                    EOF
+            -   postupdate_version: |
+                    export PIP_FIND_LINKS="file://`pwd`/dist"
+                    $BASE_PYTHON setup.py sdist bdist_wheel
+                    echo $PIP_FIND_LINKS
+            -   postinstall_utility: |
+                    # Install the version from this repo instead of the invirtualenv from pypi
+                    $BASE_PYTHON -m pip install .
+        requires: [verify_test_package]
+
+    verify_rpm_centos8:
+        template: python/package_rpm
+        environment:
+            PUBLISH: False
+        image: centos:8
+        steps:
+            -   postmotd: |
+                    cat > deploy.conf <<EOF
+                    [global]
+                    name = serviceping
+                    description = invirtualenv utility for deploying python applicatons
+                    version = 18.8.1
+                    link_bin_files = True
+                    virtualenv_dir = /var/lib/virtualenvs
+                    basepython=/usr/bin/python3
+
+                    [pip]
+                    deps:
+                        serviceping==18.8.1
+
+                    [rpm_package]
+                    basepython=/usr/bin/python3
+                    deps:
+                        python3
+                    EOF
+            -   postupdate_version: |
+                    export PIP_FIND_LINKS="file://`pwd`/dist"
+                    $BASE_PYTHON setup.py sdist bdist_wheel
+                    echo $PIP_FIND_LINKS
+            -   postinstall_utility: |
+                    # Install the version from this repo instead of the invirtualenv from pypi
+                    $BASE_PYTHON -m pip install .
+        requires: [verify_test_package]
+
+    verify_rpm_fedora:
+        template: python/package_rpm
+        environment:
+            PUBLISH: False
+        image: fedora
+        steps:
+            - postmotd: |
+                cat > deploy.conf <<EOF
+                [global]
+                name = serviceping
+                description = invirtualenv utility for deploying python applicatons
+                version = 18.8.1
+                link_bin_files = True
+                virtualenv_dir = /var/lib/virtualenvs
+                basepython=/usr/bin/python3
+
+                [pip]
+                deps:
+                    serviceping==18.8.1
+
+                [rpm_package]
+                basepython=/usr/bin/python3
+                deps:
+                    python3
+                EOF
+            - postupdate_version: |
+                export PIP_FIND_LINKS="file://`pwd`/dist"
+                $BASE_PYTHON setup.py sdist bdist_wheel
+                echo $PIP_FIND_LINKS
+            - postinstall_utility: |
+                # Install the version from this repo instead of the invirtualenv from pypi
+                $BASE_PYTHON -m pip install .
+        requires: [verify_test_package]
+
+    # Generate a package version to publish
+    generate_version:
+        template: python/generate_version
+        requires: [validate_test, validate_lint, validate_codestyle, validate_safetydb, validate_security, verify_rpm_centos7, verify_rpm_centos8, verify_rpm_fedora]
+
+    publish_test_pypi:
+        template: python/package_python
+        environment:
+            PUBLISH: True
+            TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        requires: [generate_version]
+
+    verify_test_package:
+        template: python/validate_pypi_package
+        environment:
+            PYPI_INDEX_URL: https://test.pypi.org/simple
+        requires: [publish_test_pypi]
   
-  verify_rpm_package:
-    template: python/package_rpm
-    environment:
-        PUBLISH: False
-    steps:
-        - postmotd: |
-            cat > deploy.conf <<EOF
-            [global]
-            name = serviceping
-            description = invirtualenv utility for deploying python applicatons
-            version = 18.8.1
-            link_bin_files = True
-            virtualenv_dir = /var/lib/virtualenvs
-            basepython=python3
-
-            [pip]
-            deps:
-                serviceping==18.8.1
-
-            [rpm_package]
-            deps:
-            EOF
-        - postinstall_utility: |
-            # Install the version from this repo instead of the invirtualenv from pypi
-            $BASE_PYTHON -m pip install .
-    requires: [verify_test_package]
-  
-  publish_prod_pypi:
-    template: python/package_python
-    environment:
-      PUBLISH: True
-    requires: [verify_rpm_package]
+    publish_prod_pypi:
+        template: python/package_python
+        environment:
+            PUBLISH: True
+        requires: [verify_rpm_package]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,11 +20,12 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 20.2.35
+version = 20.3.4
 
 [options]
 install_requires =
     defusedxml
+    distro
     jinja2
     requests>=2.22.0
     six>=1.5


### PR DESCRIPTION
Generate rpms with the proper rpms to bootstrap the virtualenv even on newer releases of centos/rhel that have a python3 package and lack a python package.

Only use the virtualenv command if the interpreter is python 2.x which lacks the venv module.

Add a method to the plugins to apply updates to the configuration for the plugins, which is used to provide items to the template context.

Add more tests to the pipeline to verify packages work on different OS versions.

## Related Issue
This is to fix issue #68 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
