### PR TITLE
Fix rpm generation on rhel8

### DIFF
--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -156,9 +156,10 @@ class InvirtualenvPlugin(object):
         hashes = {}
         with working_dir(wheeldir):
             logger.debug('Making sure the wheel package is installed')
+            subprocess.check_call(self.pip_cmd + ['install', '-U', 'pip'])  # nosec
             subprocess.check_call(self.pip_cmd + ['install', 'wheel'])  # nosec
             deps = self.config['pip'].get('deps', []) + ['invirtualenv']
-            cmd = self.pip_cmd + ['-q', 'wheel', '-w', '.'] + deps
+            cmd = self.pip_cmd + ['wheel', '-w', '.'] + deps
             logger.debug('Running pip command %r to generate wheel packages', cmd)
             subprocess.check_call(cmd)  # nosec
             for filename in os.listdir('.'):

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -81,7 +81,7 @@ class InvirtualenvPlugin(object):
             pip_exe = os.path.join(bin_dir, 'pip3')
             if os.path.exists(pip_exe):
                 return [pip_exe]
-            return os.path.join(bin_dir, 'pip')
+            return [os.path.join(bin_dir, 'pip')]
 
     def supported_formats(self):
         """

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -148,7 +148,7 @@ class InvirtualenvPlugin(object):
         hashes = {}
         with working_dir(wheeldir):
             logger.debug('Making sure the wheel package is installed')
-            subprocess.check_call([self.pip_cmd, 'install', 'wheel'])
+            subprocess.check_call(self.pip_cmd + ['install', 'wheel'])  # nosec
             deps = self.config['pip'].get('deps', []) + ['invirtualenv']
             cmd = self.pip_cmd + ['-q', 'wheel', '-w', '.'] + deps
             logger.debug('Running pip command %r to generate wheel packages', cmd)

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -103,6 +103,7 @@ class InvirtualenvPlugin(object):
         original_directory = os.getcwd()
         with InTemporaryDirectory():
             tempdir = os.getcwd()
+
             wheel_dir = 'wheels'
             os.makedirs(wheel_dir)
             hashes = self.generate_wheel_packages(wheel_dir)
@@ -146,6 +147,8 @@ class InvirtualenvPlugin(object):
             return {}
         hashes = {}
         with working_dir(wheeldir):
+            logger.debug('Making sure the wheel package is installed')
+            subprocess.check_call([self.pip_cmd, 'install', 'wheel'])
             deps = self.config['pip'].get('deps', []) + ['invirtualenv']
             cmd = self.pip_cmd + ['-q', 'wheel', '-w', '.'] + deps
             logger.debug('Running pip command %r to generate wheel packages', cmd)

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -74,7 +74,7 @@ class InvirtualenvPlugin(object):
             python_executable = sys.executable
         bin_dir = os.path.dirname(python_executable)
         try:
-            output = subprocess.check_output([python_executable, '-m', 'pip'])
+            output = subprocess.check_output([python_executable, '-m', 'pip'])  # nosec
             return [python_executable, '-m', 'pip']
         except subprocess.CalledProcessError:
             # Try to work around broken pip module

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -73,7 +73,15 @@ class InvirtualenvPlugin(object):
         if not python_executable:
             python_executable = sys.executable
         bin_dir = os.path.dirname(python_executable)
-        return [python_executable, '-m', 'pip']
+        try:
+            output = subprocess.check_output([python_executable, '-m', 'pip'])
+            return [python_executable, '-m', 'pip']
+        except subprocess.CalledProcessError:
+            # Try to work around broken pip module
+            pip_exe = os.path.join(bin_dir, 'pip3')
+            if os.path.exists(pip_exe):
+                return [pip_exe]
+            return os.path.join(bin_dir, 'pip')
 
     def supported_formats(self):
         """

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -109,7 +109,11 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         try:
             minor = int(distro.minor_version())
         except ValueError:
-            minor = 0
+            with open('/etc/system-release') as fh:
+                try:
+                    minor = int(fh.read().strip().split()[3].split('.')[1])
+                except (IndexError, ValueError):
+                    minor = 0
 
         self.config['global']['distro.name()'] = distro.name()
         self.config['global']['distro.major_version()'] = major

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -46,10 +46,18 @@ chmod 755 %{buildroot}/usr/share/%{name}_%{version}/package_scripts/pre_uninstal
 %post
 export RPM_ARG="$1"
 export PATH=$PATH:/opt/python/bin:/usr/local/bin
+export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
-{% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"{% endif %}
-/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+{% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
+if [ -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip3" ]; then
+    export PIP_CMD="pip3"
+fi
+if [ -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD" ]; then
+    /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python -m ensurepip
+fi
+{% endif %}
+/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
 
 # Change into the directory containing this package's invirtualenv deployment configuration and run the invirtualenv_deployer
 # to deploy the application in this rpm package.

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -49,7 +49,7 @@ export PATH=$PATH:/opt/python/bin:/usr/local/bin
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
 {% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"{% endif %}
-/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip install -q --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
 
 # Change into the directory containing this package's invirtualenv deployment configuration and run the invirtualenv_deployer
 # to deploy the application in this rpm package.

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -118,7 +118,7 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         if major > 7 or (major == 7 and minor > 6):
             self.config['rpm_package']['bootstrap_deps'] = ['python3', 'python3-pip']  # RHEL 7.7 and newer
         else:
-            self.config['rpm_package']['bootstrap_deps'] = ['python-virtualenv']  # RHEL releases before 7.6
+            self.config['rpm_package']['bootstrap_deps'] = ['python', 'python-pip', 'python-virtualenv']  # RHEL releases before 7.6
 
     def system_requirements_ok(self):
         if find_executable('rpmbuild'):

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -50,11 +50,9 @@ export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
 {% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
-if [ ! -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip3" ]; then
-    export PIP_CMD="pip3"
-fi
-if [ ! -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD" ]; then
-    /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python -m ensurepip
+RC="$?"
+if [ "$RC" != "0" ]' then
+    virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 fi
 {% endif %}
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
@@ -106,6 +104,7 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         gbasepython = self.config['global'].get('basepython', '').strip()
         if not basepython and gbasepython:
             self.config['rpm_package']['basepython'] = gbasepython
+            self.config['global']['basepython'] = gbasepython
 
         # In some cases distro returns an empty string '' instead of 0, so we can't assume the value returned from
         # the calls to get that information is always an integer.

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -50,10 +50,10 @@ export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
 {% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
-if [ -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip3" ]; then
+if [ ! -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip3" ]; then
     export PIP_CMD="pip3"
 fi
-if [ -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD" ]; then
+if [ ! -e "/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD" ]; then
     /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python -m ensurepip
 fi
 {% endif %}

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -116,7 +116,7 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         self.config['global']['distro.minor_version()'] = minor
 
         if major > 7 or (major == 7 and minor > 6):
-            self.config['rpm_package']['bootstrap_deps'] = ['python3']  # RHEL 7.7 and newer
+            self.config['rpm_package']['bootstrap_deps'] = ['python3', 'python3-pip']  # RHEL 7.7 and newer
         else:
             self.config['rpm_package']['bootstrap_deps'] = ['python-virtualenv']  # RHEL releases before 7.6
 

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -49,12 +49,12 @@ export PATH=$PATH:/opt/python/bin:/usr/local/bin
 export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
-{% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
+{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
 RC="$?"
 if [ "$RC" != "0" ]; then
     virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 fi
-{% endif %}
+
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
 
 # Change into the directory containing this package's invirtualenv deployment configuration and run the invirtualenv_deployer

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -51,7 +51,7 @@ export PIP_CMD="pip"
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
 {% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
 RC="$?"
-if [ "$RC" != "0" ]' then
+if [ "$RC" != "0" ]; then
     virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 fi
 {% endif %}

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -26,8 +26,9 @@ AutoReqProv: no
 {% if rpm_package['bootstrap_deps'] %}
 # Install deps for {{ global['distro.name()'] }} {{ global['distro.major_version()'] }}.{{global['distro.minor_version()']}}
 Requires(post): {% for package in rpm_package['bootstrap_deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}
-{% endif %}
-{% if rpm_package['deps'] %}Requires: {% for package in rpm_package['deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}{% endif %}
+{% endif %}{% if rpm_package['deps'] %}
+# RPM Package dependencies
+Requires: {% for package in rpm_package['deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}{% endif %}
 
 %description
 {{rpm_package['description']|default('No description')}}
@@ -45,8 +46,13 @@ chmod 755 %{buildroot}/usr/share/%{name}_%{version}/package_scripts/pre_uninstal
 %post
 export RPM_ARG="$1"
 export PATH=$PATH:/opt/python/bin:/usr/local/bin
+
+# Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
 {% if 'python-virtualenv' in rpm_package['bootstrap_deps'] %}virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer{% else %}{{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"{% endif %}
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/pip install -q --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+
+# Change into the directory containing this package's invirtualenv deployment configuration and run the invirtualenv_deployer
+# to deploy the application in this rpm package.
 cd /usr/share/%{name}_%{version}
 /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/python /usr/share/%{name}_%{version}/package_scripts/post_install.py
 
@@ -93,16 +99,21 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         if not basepython and gbasepython:
             self.config['rpm_package']['basepython'] = gbasepython
 
+        # In some cases distro returns an empty string '' instead of 0, so we can't assume the value returned from
+        # the calls to get that information is always an integer.
         try:
             major = int(distro.major_version())
-            minor = int(distro.minor_version())
         except ValueError:
             major = 0
+
+        try:
+            minor = int(distro.minor_version())
+        except ValueError:
             minor = 0
 
         self.config['global']['distro.name()'] = distro.name()
-        self.config['global']['distro.major_version()'] = distro.major_version()
-        self.config['global']['distro.minor_version()'] = distro.minor_version()
+        self.config['global']['distro.major_version()'] = major
+        self.config['global']['distro.minor_version()'] = minor
 
         if major > 7 or (major == 7 and minor > 6):
             self.config['rpm_package']['bootstrap_deps'] = ['python3']  # RHEL 7.7 and newer

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -23,7 +23,10 @@ Packager: {{rpm_package['packager']|default('Verizon')}}
 URL: {{global['url']|default('https://github.com/yahoo/invirtualenv')}}
 AutoReqProv: no
 {% if rpm_package['noarch'] %}BuildArch: noarch{% endif %}
-{% if rpm_package['bootstrap_deps'] %}Requires(post): {% for package in rpm_package['bootstrap_deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}{% endif %}
+{% if rpm_package['bootstrap_deps'] %}
+# Install deps for {{ global['distro.name()'] }} {{ global['distro.major_version()'] }}.{{global['distro.minor_version()']}}
+Requires(post): {% for package in rpm_package['bootstrap_deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}
+{% endif %}
 {% if rpm_package['deps'] %}Requires: {% for package in rpm_package['deps'] %}{{package}}{{ ", " if not loop.last }}{% endfor %}{% endif %}
 
 %description
@@ -97,6 +100,9 @@ class InvirtualenvRPM(InvirtualenvPlugin):
             major = 0
             minor = 0
 
+        self.config['global']['distro.name()'] = distro.name()
+        self.config['global']['distro.major_version()'] = distro.major_version()
+        self.config['global']['distro.minor_version()'] = distro.minor_version()
 
         if major > 7 or (major == 7 and minor > 6):
             self.config['rpm_package']['bootstrap_deps'] = ['python3']  # RHEL 7.7 and newer

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -52,10 +52,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3
+                    basepython=/usr/bin/python3.6
                     deps:
-                        python34
-                        python34-pip
+                        python36
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -55,6 +55,7 @@ jobs:
                     basepython=/usr/bin/python3
                     deps:
                         python34
+                        python34-pip
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -43,7 +43,7 @@ jobs:
                     name = serviceping
                     description = invirtualenv utility for deploying python applicatons
                     version = 18.8.1
-                    link_bin_files = False
+                    link_bin_files = True
                     virtualenv_dir = /var/lib/virtualenvs
                     basepython=python
 
@@ -52,9 +52,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python
+                    basepython=/usr/bin/python3
                     deps:
-                        python
+                        python34
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -61,6 +61,7 @@ jobs:
                     $BASE_PYTHON setup.py sdist bdist_wheel
                     echo $PIP_FIND_LINKS
             -   postinstall_utility: |
+                    yum install -y python-pip
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
         requires: [~commit, ~pr]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -193,3 +193,4 @@ jobs:
         environment:
             PUBLISH: True
         requires: [verify_test_package]
+

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -31,6 +31,40 @@ jobs:
         requires: [~commit, ~pr]
 
     # Check that the code can generate a valid rpm packages
+    verify_rpm_centos6:
+        template: python/package_rpm
+        environment:
+            PUBLISH: False
+        image: centos:6
+        steps:
+            -   postmotd: |
+                    cat > deploy.conf <<EOF
+                    [global]
+                    name = serviceping
+                    description = invirtualenv utility for deploying python applicatons
+                    version = 18.8.1
+                    link_bin_files = True
+                    virtualenv_dir = /var/lib/virtualenvs
+                    basepython=python
+
+                    [pip]
+                    deps:
+                        serviceping==18.8.1
+
+                    [rpm_package]
+                    basepython=/usr/bin/python
+                    deps:
+                        python
+                    EOF
+            -   postupdate_version: |
+                    export PIP_FIND_LINKS="file://`pwd`/dist"
+                    $BASE_PYTHON setup.py sdist bdist_wheel
+                    echo $PIP_FIND_LINKS
+            -   postinstall_utility: |
+                    # Install the version from this repo instead of the invirtualenv from pypi
+                    $BASE_PYTHON -m pip install .
+        requires: [~commit, ~pr]
+
     verify_rpm_centos7:
         template: python/package_rpm
         environment:
@@ -136,7 +170,10 @@ jobs:
     # Generate a package version to publish
     generate_version:
         template: python/generate_version
-        requires: [validate_test, validate_lint, validate_codestyle, validate_safetydb, validate_security, verify_rpm_centos7, verify_rpm_centos8, verify_rpm_fedora]
+        requires: [
+            validate_test, validate_lint, validate_codestyle, validate_safetydb, validate_security,
+            verify_rpm_centos6, verify_rpm_centos7, verify_rpm_centos8, verify_rpm_fedora
+        ]
 
     publish_test_pypi:
         template: python/package_python

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -45,16 +45,16 @@ jobs:
                     version = 18.8.1
                     link_bin_files = True
                     virtualenv_dir = /var/lib/virtualenvs
-                    basepython=/usr/bin/python3.6
+                    basepython=/usr/bin/python
 
                     [pip]
                     deps:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3.6
+                    basepython=/usr/bin/python
                     deps:
-                        python36
+                        python
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -193,4 +193,3 @@ jobs:
         environment:
             PUBLISH: True
         requires: [verify_test_package]
-

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -155,4 +155,4 @@ jobs:
         template: python/package_python
         environment:
             PUBLISH: True
-        requires: [verify_rpm_package]
+        requires: [verify_test_package]

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -64,6 +64,7 @@ jobs:
                     yum install -y python-pip
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
+            -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     verify_rpm_centos7:
@@ -98,6 +99,7 @@ jobs:
             -   postinstall_utility: |
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
+            -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     verify_rpm_centos8:
@@ -132,6 +134,7 @@ jobs:
             -   postinstall_utility: |
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
+            -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     verify_rpm_fedora:
@@ -166,6 +169,7 @@ jobs:
             - postinstall_utility: |
                 # Install the version from this repo instead of the invirtualenv from pypi
                 $BASE_PYTHON -m pip install .
+            -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     # Generate a package version to publish

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -176,7 +176,7 @@ jobs:
     generate_version:
         template: python/generate_version
         requires: [
-            validate_test, validate_lint, validate_codestyle, validate_safetydb, validate_security,
+            validate_test, validate_lint, validate_codestyle, validate_dep, validate_security,
             verify_rpm_centos6, verify_rpm_centos7, verify_rpm_centos8, verify_rpm_fedora
         ]
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -198,4 +198,3 @@ jobs:
         environment:
             PUBLISH: True
         requires: [verify_test_package]
-

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -198,3 +198,4 @@ jobs:
         environment:
             PUBLISH: True
         requires: [verify_test_package]
+

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -45,16 +45,16 @@ jobs:
                     version = 18.8.1
                     link_bin_files = True
                     virtualenv_dir = /var/lib/virtualenvs
-                    basepython=/usr/bin/python
+                    basepython=/usr/bin/python3.6
 
                     [pip]
                     deps:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python
+                    basepython=/usr/bin/python3.6
                     deps:
-                        python
+                        python36
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -45,7 +45,7 @@ jobs:
                     version = 18.8.1
                     link_bin_files = True
                     virtualenv_dir = /var/lib/virtualenvs
-                    basepython=python
+                    basepython=/usr/bin/python3.6
 
                     [pip]
                     deps:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -43,7 +43,7 @@ jobs:
                     name = serviceping
                     description = invirtualenv utility for deploying python applicatons
                     version = 18.8.1
-                    link_bin_files = True
+                    link_bin_files = False
                     virtualenv_dir = /var/lib/virtualenvs
                     basepython=python
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 20.3.23
+version = 20.3.24
 
 [options]
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 20.3.4
+version = 20.3.23
 
 [options]
 install_requires =


### PR DESCRIPTION
This is to fix issues with RPM generation.

- Fix the rpm plugin to honor the basepython setting in the rpm_package section of the deploy.conf.
- Make the rpms use different bootstrap dependencies depending on the distro release (the python interpreter names and methods to generate virtualenvs are different in different OS releases)
- Add additional validations that build rpms on Centos6, Centos7 and Centos8 to ensure all supported versions of Centos build for the pull requests.
- Add code to determine the correct pip command to use since some of the Python interpreters available for Centos have old or broken versions of pip.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
