### PR TITLE
Fix the detection of packages that are architecture specific

### DIFF
--- a/changelog.d/5.bugfix.md
+++ b/changelog.d/5.bugfix.md
@@ -1,0 +1,1 @@
+Fix the rpm package architecture in created packages

--- a/changelog.d/6.feature.md
+++ b/changelog.d/6.feature.md
@@ -1,0 +1,1 @@
+Add a bin_dir setting for the rpm plugin that allows specifying the directory to create bin links into.

--- a/invirtualenv/cli.py
+++ b/invirtualenv/cli.py
@@ -6,13 +6,26 @@ import logging
 import os
 import shutil
 import sys
+from . import __version__ as invirtualenv_version
 from .config import get_configuration_dict
 from .contextmanager import InTemporaryDirectory
 from .exceptions import PackageGenerationFailure
 from .plugin import create_package, create_package_configuration, get_package_plugin, package_formats
 
 
-LOGGER = logging.getLogger(__name__)
+logger_name = os.path.basename(sys.argv[0]) if __name__ == '__main__' else __name__
+log_level = logging.INFO
+log_level_name = os.environ.get('INVIRTUALENV_LOG_LEVEL', 'info').lower()
+log_level = logging.INFO
+if log_level_name in ['debug']:
+    log_level = logging.DEBUG
+elif log_level_name in ['warn', 'warning']:
+    log_level = logging.WARNING
+
+logging.basicConfig(level=log_level, format='%(asctime)s %(levelname)-5s [%(filename)s:%(lineno)d] %(message)s',
+                    datefmt='%Y%m%d:%H:%M:%S')
+
+LOGGER = logging.getLogger(logger_name)
 
 
 def parse_cli_arguments():
@@ -21,8 +34,6 @@ def parse_cli_arguments():
     package_choices = package_formats()
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('--debug', default=False, action='store_true', help='Enable debug logging')
 
     parser.add_argument('--deploy_conf', default='deploy.conf', help='Deploy configuration filename or url')
     command_parser = parser.add_subparsers(title='command', dest='command')
@@ -131,10 +142,8 @@ def list_plugins_command(args):
 
 
 def main(test=False):
+    LOGGER.debug('Invirtualenv version %s', invirtualenv_version)
     args = parse_cli_arguments()
-
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
 
     rc = 0
     output = ''

--- a/invirtualenv/cli.py
+++ b/invirtualenv/cli.py
@@ -22,6 +22,8 @@ def parse_cli_arguments():
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
+    parser.add_argument('--debug', default=False, action='store_true', help='Enable debug logging')
+
     parser.add_argument('--deploy_conf', default='deploy.conf', help='Deploy configuration filename or url')
     command_parser = parser.add_subparsers(title='command', dest='command')
     list_plugins_parser = command_parser.add_parser('list_plugins', help='List the installed invirtualenv plugins')
@@ -130,6 +132,9 @@ def list_plugins_command(args):
 
 def main(test=False):
     args = parse_cli_arguments()
+
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
 
     rc = 0
     output = ''

--- a/invirtualenv/config.py
+++ b/invirtualenv/config.py
@@ -234,8 +234,8 @@ def parse_arguments(configuration=None):
         '--python',
         '-p',
         default=config['global']['basepython'],
-        help='The Python interpreter to use, e.g., --python=python3.5 '
-             'will use the python3.5 interpreter to create the new '
+        help='The Python interpreter to use, e.g., --python=python3.9 '
+             'will use the python3.9 interpreter to create the new '
              'environment.  The default is the interpreter that virtualenv '
              'was installed with.'
     )

--- a/invirtualenv/config.py
+++ b/invirtualenv/config.py
@@ -183,6 +183,7 @@ def generate_parsed_config_file(source=None, dest=None):
     template = Template(config_data)
     result = template.render(**os.environ)
 
+    logging.debug('parsed_config_file', result)
     if not dest:
         with tempfile.NamedTemporaryFile(
             delete=False, suffix='.conf'

--- a/invirtualenv/config.py
+++ b/invirtualenv/config.py
@@ -183,7 +183,7 @@ def generate_parsed_config_file(source=None, dest=None):
     template = Template(config_data)
     result = template.render(**os.environ)
 
-    logging.debug('parsed_config_file', result)
+    logging.debug('parsed_config_file %s', result)
     if not dest:
         with tempfile.NamedTemporaryFile(
             delete=False, suffix='.conf'

--- a/invirtualenv/deploy.py
+++ b/invirtualenv/deploy.py
@@ -274,7 +274,7 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
             )
 
     # By default don't use local wheels.
-    use_local_wheels = config['global'].getboolean('use_local_wheels', False)
+    use_local_wheels = config['global'].get('use_local_wheels', 'false').lower() in ['1', 'true', 'yes', 'on']
 
     if verbose:
         display_header('Building virtualenv')

--- a/invirtualenv/deploy.py
+++ b/invirtualenv/deploy.py
@@ -275,6 +275,8 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
 
     # By default don't use local wheels.
     use_local_wheels = config['global'].get('use_local_wheels', 'false').lower() in ['1', 'true', 'yes', 'on']
+    use_index = str(not use_local_wheels)  # default is to disable the index if using local wheels
+    use_index = config['global'].get('use_index', use_index).lower() in ['1', 'true', 'yes', 'on']
 
     if verbose:
         display_header('Building virtualenv')
@@ -287,7 +289,6 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
     )
 
     deps = config['pip']['deps']
-    use_index = config['global'].get('use_index', True)
     if verbose:
         display_header('Installing python package dependencies')
     try:

--- a/invirtualenv/deploy.py
+++ b/invirtualenv/deploy.py
@@ -274,7 +274,7 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
             )
 
     # By default don't use local wheels.
-    use_local_wheels = config['global'].get('use_local_wheels', False)
+    use_local_wheels = config['global'].getboolean('use_local_wheels', False)
 
     if verbose:
         display_header('Building virtualenv')
@@ -287,7 +287,7 @@ def build_deploy_virtualenv(arguments=None, configuration=None, update_existing=
     )
 
     deps = config['pip']['deps']
-    use_index = True
+    use_index = config['global'].get('use_index', True)
     if verbose:
         display_header('Installing python package dependencies')
     try:

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -161,7 +161,7 @@ class InvirtualenvPlugin(object):
             with open('deploy.conf.unparsed', 'w') as deploy_conf_handle:
                 self.loaded_configuration.write(deploy_conf_handle)
             with open('deploy.conf.unparsed') as fh:
-                logger.debug('deploy.conf.unparsed', fh.read())
+                logger.debug('deploy.conf.unparsed %s', fh.read())
             generate_parsed_config_file('deploy.conf.unparsed', 'deploy.conf')
             package = self.run_package_command(hashes, wheel_dir=wheel_dir)  # pylint: disable=E1128,E1111
             if package and os.path.exists(package):

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -196,11 +196,11 @@ class InvirtualenvPlugin(object):
                         cmd += ['-a', self.hash]
                     cmd += [filename]
                     logger.debug('Running pip command %r to generate package hash for %r', cmd, filename)
-                    hash_result = subprocess.check_output(cmd).decode()
+                    hash_result = subprocess.check_output(cmd).decode()  # nosec
                     if file_wheel_name and file_wheel_version:
                         logger.debug(f"file_wheel_name==file_wheel_version")
-                        hashes[f'{file_wheel_name}=={file_wheel_version}'] = '='.join(hash_result.split(os.linesep)[1].split('=')[1:])  # nosec
-                        logger.debug('Got requirements line %r', hashes[f'{file_wheel_name}=={file_wheel_version}'])
+                        hashes['{file_wheel_name}=={file_wheel_version}'.format(**locals())] = '='.join(hash_result.split(os.linesep)[1].split('=')[1:])
+                        logger.debug('Got requirements line %r', hashes['{file_wheel_name}=={file_wheel_version}'.format(**locals())])
                     else:
                         hashes[filename] = '='.join(hash_result.split(os.linesep)[1].split('=')[1:])  # nosec
                         logger.debug('Got requirements line %r', hashes[filename])
@@ -233,7 +233,11 @@ class InvirtualenvPlugin(object):
 
             deps = []
             for package_name, package_hash in hashes.items():
-                deps.append('{package_name} --hash={package_hash}'.format(package_name=package_name, package_hash=package_hash))
+                print(self.config['global'])
+                if self.config['global'].get('use_local_wheels', 'false').lower() in ['1', 'true', 'yes', 'on']:
+                    deps.append('{package_name} --hash={package_hash}'.format(package_name=package_name, package_hash=package_hash))
+                else:
+                    deps.append(package_name)
             self.config['pip']['deps'] = deps
 
             if self.hash:

--- a/invirtualenv/plugin_base.py
+++ b/invirtualenv/plugin_base.py
@@ -171,7 +171,7 @@ class InvirtualenvPlugin(object):
             logger.debug('Making sure the wheel package is installed')
             subprocess.check_call(self.pip_cmd + ['install', '-U', 'pip'])  # nosec
             subprocess.check_call(self.pip_cmd + ['install', 'wheel'])  # nosec
-            deps = self.config['pip'].get('deps', []) + ['invirtualenv']
+            deps = self.config['pip'].get('deps', []) + ['invirtualenv', 'configparser']
             cmd = self.pip_cmd + ['wheel', '-w', '.'] + deps
             logger.debug('Running pip command %r to generate wheel packages', cmd)
             try:
@@ -210,7 +210,7 @@ class InvirtualenvPlugin(object):
                     logger.debug('Running pip command %r to generate package hash for %r', cmd, filename)
                     hash_result = subprocess.check_output(cmd).decode()  # nosec
                     if file_wheel_name and file_wheel_version:
-                        logger.debug(f"file_wheel_name==file_wheel_version")
+                        logger.debug("file_wheel_name==file_wheel_version".format(**locals()))
                         hashes['{file_wheel_name}=={file_wheel_version}'.format(**locals())] = '='.join(hash_result.split(os.linesep)[1].split('=')[1:])
                         logger.debug('Got requirements line %r', hashes['{file_wheel_name}=={file_wheel_version}'.format(**locals())])
                     else:

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -325,6 +325,8 @@ def install_requirements(
         except subprocess.CalledProcessError as error:
             logger.exception('PIP install operation failed')
             print(error.output.decode())
+            sys.stdout.flush()
+            sys.stderr.flush()
             raise BuildException('PIP install operation failed')
 
     after_binfiles_filename = os.path.join(virtualenv, 'conf/binfiles_postdeploy.json')

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -311,7 +311,6 @@ def install_requirements(
         command = [
             os.path.join(virtualenv_bin, 'pip'),
             'install',
-            # '--cache-dir', pip_cache_dir,
             '-r', requirement,
         ] + extra_pip_args
         logger.debug('Running command: %s', ' '.join(command))

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -290,8 +290,8 @@ def install_requirements(
         # packages from pypi we will be installing wheels from local dir.
         package_data_dir_name = os.path.basename(virtualenv)
         package_data_dir = os.path.join("/usr/share/", package_data_dir_name)
-        wheels_dir = os.path.join(package_data_dir, "wheels")
-        extra_pip_args += ['--find-links', wheels_dir]
+        wheels_dir = os.path.join(package_data_dir, "wheels/")
+        extra_pip_args += ['--find-links', wheels_dir, '--prefer-binary']
 
     user_uid = None
     user_gid = None
@@ -311,7 +311,7 @@ def install_requirements(
         command = [
             os.path.join(virtualenv_bin, 'pip'),
             'install',
-            '--cache-dir', pip_cache_dir,
+            # '--cache-dir', pip_cache_dir,
             '-r', requirement,
         ] + extra_pip_args
         logger.debug('Running command: %s', ' '.join(command))

--- a/invirtualenv_plugins/docker.py
+++ b/invirtualenv_plugins/docker.py
@@ -134,7 +134,7 @@ class InvirtualenvDocker(InvirtualenvPlugin):
     def system_requirements_ok(self):
         if find_executable('docker'):
             return True
-        logger.debug('The docker command is not present, disabling the rpm plugin')
+        logger.debug('The docker command is not present, disabling the docker plugin')
         return False
 
     def generate_wheel_archive(self, filename=None):

--- a/invirtualenv_plugins/docker_scripts/post_build.py
+++ b/invirtualenv_plugins/docker_scripts/post_build.py
@@ -1,0 +1,25 @@
+from invirtualenv.config import get_configuration
+from invirtualenv.deploy import link_deployed_bin_files
+
+
+
+def main():
+    config = get_configuration()
+    link_bin_files = config['docker_container'].get('link_bin_files', '')
+    if link_bin_files:
+        link_bin_files = config['docker_container'].getboolean('link_bin_files')
+    else:
+        link_bin_files = config['docker_container'].getboolean('link_bin_files')
+    if not link_bin_files:
+        return 0
+
+    bin_dir = config['docker_container'].get('bin_dir', '')
+    if not bin_dir:
+        bin_dir = config['global'].get('bin_dir', '/usr/bin')
+
+    link_deployed_bin_files(venv_directory, bin_dir)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -82,16 +82,19 @@ rm -rf /usr/share/%{name}_%{version}
 """
 
 RPM_CONFIG_DEFAULT = """[rpm_package]
+bin_dir =
 deps:
 files:
 """
 
 class InvirtualenvRPM(InvirtualenvPlugin):
+    hash = 'sha256'
     package_formats = ['rpm']
     package_template = SPEC_TEMPLATE
     config_default = RPM_CONFIG_DEFAULT
     config_types = {
         'rpm_package': {
+            'bin_dir': str,
             'deps': list,
             'files': list,
         }
@@ -159,7 +162,6 @@ class InvirtualenvRPM(InvirtualenvPlugin):
                 file_source_dest[1] = [file_source_dest[1]]
 
             self.config['rpm_package']['file_tuples'].append(file_source_dest)
-            print(f'file source dest: {file_source_dest}')
 
     def copy_files_to_tempdir(self, tempdir):
         if 'file_tuples' not in self.config['rpm_package'].keys() or not self.config['rpm_package']['file_tuples']:
@@ -172,7 +174,7 @@ class InvirtualenvRPM(InvirtualenvPlugin):
                 full_source = os.path.join(self.source_dir, source)
             if not os.path.exists(full_source):
                 raise FileNotFoundError('[rpm_page] files entry %r not found' % full_source)
-            print('copying', full_source, full_dest)
+            logger.debug('copying', full_source, full_dest)
             os.makedirs(os.path.dirname(full_dest), exist_ok=True)
             shutil.copyfile(full_source, full_dest)
 

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -54,7 +54,7 @@ export PATH=$PATH:/opt/python/bin:/usr/local/bin
 export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
-print('Attempting to build bootstrap venv using {{rpm_package['base_python']}}')
+echo "Attempting to build bootstrap venv using {{rpm_package['basepython']}}"
 if [ ! -e "{{rpm_package['basepython']}}" ]; then
     echo "The python_interpreter was not found"
 fi

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -60,7 +60,11 @@ if [ "$RC" != "0" ]; then
     virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 fi
 
-/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+/usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --no-index --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+RC="$?"
+if [ "$RC" != "0" ]; then
+    /usr/share/%{name}_%{version}/invirtualenv_deployer/bin/$PIP_CMD install --find-links=/usr/share/%{name}_%{version}/wheels invirtualenv configparser
+fi
 
 # Change into the directory containing this package's invirtualenv deployment configuration and run the invirtualenv_deployer
 # to deploy the application in this rpm package.

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -57,6 +57,7 @@ export PIP_CMD="pip"
 echo "Attempting to build bootstrap venv using {{rpm_package['basepython']}}"
 if [ ! -e "{{rpm_package['basepython']}}" ]; then
     echo "The python_interpreter was not found"
+    exit 1
 fi
 
 {{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -54,6 +54,11 @@ export PATH=$PATH:/opt/python/bin:/usr/local/bin
 export PIP_CMD="pip"
 
 # Bootstrap a Python virtualenv with the invirtualenv utility deployed in it
+print('Attempting to build bootstrap venv using {{rpm_package['base_python']}}')
+if [ ! -e "{{rpm_package['basepython']}}" ]; then
+    echo "The python_interpreter was not found"
+fi
+
 {{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
 RC="$?"
 if [ "$RC" != "0" ]; then

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -202,9 +202,8 @@ class InvirtualenvRPM(InvirtualenvPlugin):
         logger.debug(self.render_template_with_config())
         logger.debug('Deploy.conf')
         logger.debug(open('deploy.conf').read())
-        print(f'CWD: {os.getcwd()}')
-        print(f'source_dir: {self.source_dir}')
-        os.system('ls -lR')
+        logger.debug('CWD: %s', os.getcwd())
+        logger.debug('source_dir: %s', self.source_dir)
         with open('package.spec', 'w') as spec_handle:
             spec_handle.write(self.render_template_with_config())
         command = [find_executable('rpmbuild'), '-ba', 'package.spec']

--- a/invirtualenv_plugins/rpm_scripts/post_install.py
+++ b/invirtualenv_plugins/rpm_scripts/post_install.py
@@ -61,8 +61,11 @@ def main():
 
     logger.debug('Using the following deploy.conf: %s' % open('deploy.conf').read())
     venv_directory = None
+    verbose = log_level == logging.DEBUG
+    if get_config_flag('pip', 'no_index'):
+        os.environ['PIP_NO_INDEX'] = "true"
     try:
-        venv_directory = build_deploy_virtualenv(update_existing=True)
+        venv_directory = build_deploy_virtualenv(update_existing=True, verbose=verbose)
         update_config(venv_directory)
     except Exception:
         print('Unable to create the python virtualenv', file=sys.stderr)

--- a/invirtualenv_plugins/rpm_scripts/post_install.py
+++ b/invirtualenv_plugins/rpm_scripts/post_install.py
@@ -65,8 +65,6 @@ def main():
     logger.debug('Using the following deploy.conf: %s' % open('deploy.conf').read())
     venv_directory = None
     verbose = log_level == logging.DEBUG
-    if get_config_flag('pip', 'no_index'):
-        os.environ['PIP_NO_INDEX'] = "true"
     try:
         venv_directory = build_deploy_virtualenv(update_existing=True, verbose=verbose)
         update_config(venv_directory)

--- a/invirtualenv_plugins/rpm_scripts/post_install.py
+++ b/invirtualenv_plugins/rpm_scripts/post_install.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 
 from configparser import ConfigParser, NoOptionError
+from invirtualenv import __version__ as invirtualenv_version
 from invirtualenv.deploy import build_deploy_virtualenv
 
 
@@ -47,6 +48,8 @@ def main():
 
     logging.basicConfig(level=log_level, format='%(asctime)s %(levelname)-5s [%(filename)s:%(lineno)d] %(message)s', datefmt='%Y%m%d:%H:%M:%S')
     logger = logging.getLogger(os.path.basename(sys.argv[0]))
+
+    logger.debug('Starting rpm package post installprocessing using invirtualenv version %s' % invirtualenv_version)
 
     logger.debug('Running post install steps, from directory %r' % os.getcwd())
     upgrade = False

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -24,7 +24,7 @@ jobs:
     validate_dep:
         template: python/validate_safety
         steps:
-            - postinit_os: $BASE_PYTHON -m pip install --upgrade pip
+            - validate_code: pypirun --upgrade_pip safety,. safety check --json -o safetydb.json || true
         requires: [~commit, ~pr]
 
     # Check code for common security issues

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,9 @@ version: 4
 shared:
     environment:
         CHANGELOG_FILENAME: docs/changelog.md
+        INVIRTUALENV_LOG_LEVEL: debug
         PACKAGE_DIRECTORY: invirtualenv
+        RPM_SCRIPTLET_DEBUG: 'True'
 
 jobs:
     # Run the unittests

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -72,7 +72,6 @@ jobs:
     verify_rpm_centos8:
         template: python/package_rpm
         environment:
-            BASE_PYTHON: python3.6
             PUBLISH: False
         image: centos:8
         steps:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -90,9 +90,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python36
+                    basepython=/usr/bin/python3.8
                     deps:
-                        python36
+                        python38
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist/"
@@ -125,9 +125,9 @@ jobs:
                     serviceping==18.8.1
 
                 [rpm_package]
-                basepython=/usr/bin/python3.8
+                basepython=/usr/bin/python3.6
                 deps:
-                    python38
+                    python36
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,6 +23,8 @@ jobs:
     # Check for use of package dependencies that have security issues
     validate_dep:
         template: python/validate_safety
+        steps:
+            - postinit_os: $BASE_PYTHON -m pip install --upgrade pip
         requires: [~commit, ~pr]
 
     # Check code for common security issues

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -72,6 +72,7 @@ jobs:
     verify_rpm_centos8:
         template: python/package_rpm
         environment:
+            BASE_PYTHON: python3.6
             PUBLISH: False
         image: centos:8
         steps:
@@ -90,12 +91,12 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3
+                    basepython=/usr/bin/python36
                     deps:
-                        python3
+                        python36
                     EOF
             -   postupdate_version: |
-                    export PIP_FIND_LINKS="file://`pwd`/dist"
+                    export PIP_FIND_LINKS="file://`pwd`/dist/"
                     $BASE_PYTHON setup.py sdist bdist_wheel
                     echo $PIP_FIND_LINKS
             -   postinstall_utility: |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -125,9 +125,9 @@ jobs:
                     serviceping==18.8.1
 
                 [rpm_package]
-                basepython=/usr/bin/python3
+                basepython=/usr/bin/python3.8
                 deps:
-                    python3
+                    python38
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 22.6.15
+version = 22.6.16
 
 [options]
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 21.2.2
+version = 22.6.15
 
 [options]
 install_requires =
@@ -38,6 +38,7 @@ install_requires =
 packages =
     invirtualenv
     invirtualenv_plugins
+    invirtualenv_plugins.docker_scripts
     invirtualenv_plugins.rpm_scripts
 
 python_requires = >=2.7.5

--- a/tests/test_plugin_base.py
+++ b/tests/test_plugin_base.py
@@ -26,7 +26,7 @@ class TestPluginBase(unittest.TestCase):
             plugin = InvirtualenvPlugin()
             plugin.hash = 'sha512'
             hashes = plugin.generate_wheel_packages(wheeldir=os.getcwd())
-            packages = [filename.split('-')[0] for filename in hashes.keys()]
+            packages = [filename.split('=')[0] for filename in hashes.keys()]
             self.assertGreater(len(hashes), 0)
             self.assertIn('invirtualenv', packages)
             self.assertIn('sha512:', list(hashes.values())[0])

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ package_name = invirtualenv
 
 [tox]
 skip_missing_interpreters = True
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 
 [testenv]
 deps = 


### PR DESCRIPTION
This will fix the noarch flag to be set properly and used in the rpm plugin.

Also enable the rpm_package setting called bin_dir that allows specifying the bin
 directory to link the bin files into.

Disables the use of the indexes by default when using local_wheels.  Without this setting pip will frequently use the packages from the repos instead of the ones in the created package.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
