### PR TITLE
Remove the EOL CentOS 7.x verification.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -34,41 +34,6 @@ jobs:
         template: python/validate_security
         requires: [~commit, ~pr]
 
-    verify_rpm_centos7:
-        template: python/package_rpm
-        environment:
-            PUBLISH: False
-        image: centos:7
-        steps:
-            -   postmotd: |
-                    cat > deploy.conf <<EOF
-                    [global]
-                    name = serviceping
-                    description = invirtualenv utility for deploying python applicatons
-                    version = 18.8.1
-                    link_bin_files = True
-                    virtualenv_dir = /var/lib/virtualenvs
-                    basepython=/usr/bin/python3
-
-                    [pip]
-                    deps:
-                        serviceping==18.8.1
-
-                    [rpm_package]
-                    basepython=/usr/bin/python3
-                    deps:
-                        python3
-                    EOF
-            -   postupdate_version: |
-                    export PIP_FIND_LINKS="file://`pwd`/dist"
-                    $BASE_PYTHON setup.py sdist bdist_wheel
-                    echo $PIP_FIND_LINKS
-            -   postinstall_utility: |
-                    # Install the version from this repo instead of the invirtualenv from pypi
-                    $BASE_PYTHON -m pip install .
-            -   preend: /usr/bin/serviceping --help
-        requires: [~commit, ~pr]
-
     verify_rpm_centos8:
         template: python/package_rpm
         environment:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ project_urls =
     Source Code = https://github.com/yahoo/invirtualenv
     Documentation = https://invirtualenv.readthedocs.io/en/latest/?badge=latest
 url = https://github.com/yahoo/invirtualenv
-version = 22.6.16
+version = 24.9.4
 
 [options]
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ package_name = invirtualenv
 
 [tox]
 skip_missing_interpreters = True
-envlist = py36, py37, py38, py39
+envlist = py39, py310, py311
 
 [testenv]
 deps = 
@@ -13,7 +13,9 @@ deps =
 	# coveralls
 commands = 
 	pytest --junitxml=pytest_{envname}.xml -o junit_suite_name={envname} --cov=invirtualenv --cov-report=xml:coverage.xml --cov-report term-missing tests/
-passenv = CI COVERALLS_REPO_TOKEN
+passenv =
+	CI
+	COVERALLS_REPO_TOKEN
 
 [testenv:pycodestyle]
 basepython = python3


### PR DESCRIPTION

CentOS 7.x is now EOL.  Remove the ci/cd jobs for CentOS 7.x.


## Motivation and Context

Remove a source of failure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project `tox -e pycodestyle` returns no errors.
- [ ] My code has no unaddressed Liniting issues and the `tox -e pylint` command returns no errors.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
