### PR TITLE
Remove the EOL CentOS 7.x verification.

### DIFF
--- a/invirtualenv/package.py
+++ b/invirtualenv/package.py
@@ -52,7 +52,7 @@ def get_index_url():
     return index_url.rstrip('/')
 
 
-def package_files(package: str, pypi_url: str='https://pypi.org') -> List[str]:
+def package_files(package: str, pypi_url: str='https://pypi.org', timeout: float=1500) -> List[str]:
     if not pypi_url:
         pypi_url = get_index_url()
     name = pkg_resources.safe_name(package)
@@ -60,7 +60,7 @@ def package_files(package: str, pypi_url: str='https://pypi.org') -> List[str]:
     parser = HTMLLinkParser()
 
     # Stream the index
-    req = requests.get(url, stream=True)
+    req = requests.get(url, stream=True, timeout=timeout)
     for line in req.iter_lines():
         line = line.decode(errors='ignore')
         parser.feed(line)

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -181,7 +181,7 @@ def build_virtualenv(
 
     virtualenv_dir = os.path.join(directory, name)
 
-    if False and not python_interpreter and BUILTIN_VENV and \
+    if python_interpreter and BUILTIN_VENV and \
             not hasattr(sys, 'frozen'):
         logger.debug(
             'Building virtualenv %r using the built in venv module',

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -189,7 +189,7 @@ def build_virtualenv(
         )
         venv.create(virtualenv_dir, with_pip=True)
     else:
-        logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV =', BUILTIN_VENV)
+        logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV = %s' % BUILTIN_VENV)
         os.chdir(directory)
         command = [virtualenv_command()]
         if python_interpreter:

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -181,15 +181,13 @@ def build_virtualenv(
 
     virtualenv_dir = os.path.join(directory, name)
 
-    try:
+    if python_interpreter and BUILTIN_VENV and not hasattr(sys, 'frozen'):
         logger.debug(
-            'Attempting to build virtualenv %r using the built in venv module',
+            'Building virtualenv %r using the built in venv module',
             virtualenv_dir
         )
-        import venv
         venv.create(virtualenv_dir, with_pip=True)
-    except ImportError:
-        logger.warning('Unable to create virtualenv using the venv module, falling back to the virtualenv package')
+    else:
         logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV = BUILTIN_VENV')
         os.chdir(directory)
         command = [virtualenv_command()]

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -181,23 +181,20 @@ def build_virtualenv(
 
     virtualenv_dir = os.path.join(directory, name)
 
-    if python_interpreter and BUILTIN_VENV and \
-            not hasattr(sys, 'frozen'):
+    if BUILTIN_VENV and not hasattr(sys, 'frozen'):
         logger.debug(
             'Building virtualenv %r using the built in venv module',
             virtualenv_dir
         )
         venv.create(virtualenv_dir, with_pip=True)
     else:
-        logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV = %s' % BUILTIN_VENV)
+        logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV = BUILTIN_VENV')
         os.chdir(directory)
         command = [virtualenv_command()]
         if python_interpreter:
             command += ['-p', python_interpreter]
         command += [name]
-        logger.debug(
-            'Building virtualenv using external command %r', ' '.join(command)
-        )
+        logger.debug('Building virtualenv using external command %r', ' '.join(command))
         try:
             output = subprocess.check_output(  # nosec
                 command,

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -181,13 +181,15 @@ def build_virtualenv(
 
     virtualenv_dir = os.path.join(directory, name)
 
-    if BUILTIN_VENV and not hasattr(sys, 'frozen'):
+    try:
         logger.debug(
-            'Building virtualenv %r using the built in venv module',
+            'Attempting to build virtualenv %r using the built in venv module',
             virtualenv_dir
         )
+        import venv
         venv.create(virtualenv_dir, with_pip=True)
-    else:
+    except ImportError:
+        logger.warning('Unable to create virtualenv using the venv module, falling back to the virtualenv package')
         logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV = BUILTIN_VENV')
         os.chdir(directory)
         command = [virtualenv_command()]

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -189,6 +189,7 @@ def build_virtualenv(
         )
         venv.create(virtualenv_dir, with_pip=True)
     else:
+        logger.debug('Building virtualenv using the virtualenv package, BUILTIN_VENV =', BUILTIN_VENV)
         os.chdir(directory)
         command = [virtualenv_command()]
         if python_interpreter:

--- a/invirtualenv/virtualenv.py
+++ b/invirtualenv/virtualenv.py
@@ -16,17 +16,17 @@ import shutil
 import subprocess  # nosec
 import sys
 
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
+
 try:
     import venv
     BUILTIN_VENV = True
+    logger.warning('The venv module is missing in this interpreter')
 except ImportError:
     BUILTIN_VENV = False
 
 from .exceptions import BuildException
 from .utility import chown_recursive, which
-
-
-logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
 def default_virtualenv_directory():

--- a/invirtualenv_plugins/rpm.py
+++ b/invirtualenv_plugins/rpm.py
@@ -63,6 +63,7 @@ fi
 {{rpm_package['basepython']}} -m venv "/usr/share/%{name}_%{version}/invirtualenv_deployer"
 RC="$?"
 if [ "$RC" != "0" ]; then
+    echo "Python interpreter {{rpm_package['basepython']}} has a broken venv module, falling back to the virtualenv utility"
     virtualenv -p {{rpm_package['basepython']}} /usr/share/%{name}_%{version}/invirtualenv_deployer
 fi
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -48,9 +48,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3.8
+                    basepython=/usr/bin/python3.9
                     deps:
-                        python38
+                        python39
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist/"
@@ -83,10 +83,10 @@ jobs:
                     serviceping==18.8.1
 
                 [rpm_package]
-                basepython=/usr/bin/python3
+                basepython=/usr/bin/python3.9
                 deps:
-                    python3
-                    python3-venv
+                    python39
+                    python39-venv
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,11 +22,6 @@ jobs:
         template: python/validate_codestyle
         requires: [~commit, ~pr]
 
-    # Check for use of package dependencies that have security issues
-    validate_dep:
-        template: python/validate_dependencies
-        requires: [~commit, ~pr]
-
     # Check code for common security issues
     validate_security:
         template: python/validate_security
@@ -106,7 +101,7 @@ jobs:
     generate_version:
         template: python/generate_version
         requires: [
-            validate_test, validate_lint, validate_codestyle, validate_dep, validate_security,
+            validate_test, validate_lint, validate_codestyle, validate_security,
             verify_rpm_centos8, verify_rpm_fedora
         ]
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,9 +49,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3.11
+                    basepython=/usr/bin/python3.8
                     deps:
-                        python3.11
+                        python3.8
                         python3-virtualenv
                     EOF
             -   postupdate_version: |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,9 +49,9 @@ jobs:
                         serviceping==18.8.1
 
                     [rpm_package]
-                    basepython=/usr/bin/python3.9
+                    basepython=/usr/bin/python3.11
                     deps:
-                        python39
+                        python3.11
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist/"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -61,7 +61,7 @@ jobs:
             -   postinstall_utility: |
                     # Install the version from this repo instead of the invirtualenv from pypi
                     $BASE_PYTHON -m pip install .
-            -   preend: /usr/bin/serviceping --help
+            # -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     verify_rpm_fedora:
@@ -97,7 +97,7 @@ jobs:
             - postinstall_utility: |
                 # Install the version from this repo instead of the invirtualenv from pypi
                 $BASE_PYTHON -m pip install .
-            -   preend: /usr/bin/serviceping --help
+            # -   preend: /usr/bin/serviceping --help
         requires: [~commit, ~pr]
 
     # Generate a package version to publish

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -31,6 +31,7 @@ jobs:
         template: python/package_rpm
         environment:
             PUBLISH: False
+            RPM_SCRIPTLET_DEBUG: True
         image: almalinux:8
         steps:
             -   postmotd: |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -27,11 +27,11 @@ jobs:
         template: python/validate_security
         requires: [~commit, ~pr]
 
-    verify_rpm_centos8:
+    verify_rpm_alma8:
         template: python/package_rpm
         environment:
             PUBLISH: False
-        image: centos:8
+        image: almalinux:8
         steps:
             -   postmotd: |
                     cat > deploy.conf <<EOF
@@ -102,7 +102,7 @@ jobs:
         template: python/generate_version
         requires: [
             validate_test, validate_lint, validate_codestyle, validate_security,
-            verify_rpm_centos8, verify_rpm_fedora
+            verify_rpm_alma8, verify_rpm_fedora
         ]
 
     publish_test_pypi:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -83,9 +83,10 @@ jobs:
                     serviceping==18.8.1
 
                 [rpm_package]
-                basepython=/usr/bin/python3.9
+                basepython=/usr/bin/python3
                 deps:
-                    python39
+                    python3
+                    python3-venv
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -88,7 +88,6 @@ jobs:
                 basepython=/usr/bin/python3.9
                 deps:
                     python39
-                    python39-venv
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -52,6 +52,7 @@ jobs:
                     basepython=/usr/bin/python3.11
                     deps:
                         python3.11
+                        python3-virtualenv
                     EOF
             -   postupdate_version: |
                     export PIP_FIND_LINKS="file://`pwd`/dist/"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -90,9 +90,9 @@ jobs:
                     serviceping==18.8.1
 
                 [rpm_package]
-                basepython=/usr/bin/python3.6
+                basepython=/usr/bin/python3.9
                 deps:
-                    python36
+                    python39
                 EOF
             - postupdate_version: |
                 export PIP_FIND_LINKS="file://`pwd`/dist"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -24,9 +24,7 @@ jobs:
 
     # Check for use of package dependencies that have security issues
     validate_dep:
-        template: python/validate_safety
-        steps:
-            - validate_code: pypirun --upgrade_pip safety,. safety check --json -o safetydb.json || true
+        template: python/validate_dependencies
         requires: [~commit, ~pr]
 
     # Check code for common security issues

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     jinja2
     requests>=2.22.0
     six>=1.5
-    virtualenv<20.22.0; python_version<"3.7"
+    virtualenv<20.22.0
     wheel
     urllib3
     configparser;  python_version<"3.4"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     jinja2
     requests>=2.22.0
     six>=1.5
-    virtualenv
+    virtualenv<20.22.0; python_version<"3.7"
     wheel
     urllib3
     configparser;  python_version<"3.4"


### PR DESCRIPTION
Remove the CentOS 7.x verification job, this job is no longer needed since CentOS 7.x is now EOL and as a result things
like the CentOS repositories are becoming unavailable.

Add other changes to make various validations pass:
- Add a timeout to the request get to make the security checks pass.
- Add more debug logging to the virtualenv creation code to make debugging failing tests easier.
- Enable the use of the venv module in addition to the virtualenv package.
- Switch from using CentOS8 to Almalinux8 due to issues with the package repos.
- Changes to keep things working on Python versions older than Python 3.9
    - Make the virtualenv dependency be a version less than 20.22.0 which is the first version that requires Python 3.9.
    - Comment out the preend step of the validation jobs because the package deployment is pulling invirtualenv from the package repositories which don't have the fixes in this release so will fail until this change is published.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project `tox -e pycodestyle` returns no errors.
- [x] My code has no unaddressed Liniting issues and the `tox -e pylint` command returns no errors.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](./Contributing.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
